### PR TITLE
add id to schedule

### DIFF
--- a/src/components/conference-day/conference-day.jade
+++ b/src/components/conference-day/conference-day.jade
@@ -193,7 +193,7 @@
                                         a(href="https://twitter.com/DJCordhose", target="_blank") @DJCordhose
     .conference-day-schedule
 
-        .container
+        .container#schedule
 
             h1 Schedule
             h2 Every conference day ticket includes:


### PR DESCRIPTION
Would make it easier to share the schedule on social media (https://ng-be.org/conference-day#schedule). Feel free to close it though, was just an idea I had.